### PR TITLE
Add functions for `MessageDigest` and `Digest` (bouncycastle)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,18 +1,32 @@
-import com.google.gson.*
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
 import com.google.gson.JsonParser
-import groovy.json.*
-import groovy.util.*
-import org.gradle.api.internal.tasks.testing.*
-import org.gradle.api.tasks.testing.logging.*
+import groovy.json.JsonOutput
+import groovy.util.Node
+import groovy.util.NodeList
+import org.gradle.api.internal.tasks.testing.DefaultTestFailure
+import org.gradle.api.internal.tasks.testing.DefaultTestMethodDescriptor
+import org.gradle.api.internal.tasks.testing.DefaultTestOutputEvent
+import org.gradle.api.internal.tasks.testing.DefaultTestSuiteDescriptor
+import org.gradle.api.internal.tasks.testing.TestCompleteEvent
+import org.gradle.api.internal.tasks.testing.TestExecuter
+import org.gradle.api.internal.tasks.testing.TestExecutionSpec
+import org.gradle.api.internal.tasks.testing.TestResultProcessor
+import org.gradle.api.internal.tasks.testing.TestStartEvent
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.gradle.jvm.tasks.Jar
-import org.gradle.plugins.signing.signatory.internal.pgp.*
-import org.jetbrains.dokka.gradle.*
-import org.jetbrains.kotlin.gradle.dsl.*
-import org.jetbrains.kotlin.gradle.plugin.*
-import org.jetbrains.kotlin.gradle.targets.js.ir.*
-import java.net.*
-import java.util.*
-import java.util.concurrent.*
+import org.gradle.plugins.signing.signatory.internal.pgp.InMemoryPgpSignatoryProvider
+import org.jetbrains.dokka.gradle.AbstractDokkaTask
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
+import org.jetbrains.kotlin.gradle.plugin.KotlinTargetWithTests
+import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.Base64
+import java.util.concurrent.CancellationException
 
 plugins {
     kotlin("multiplatform") version "2.0.10"
@@ -36,7 +50,7 @@ var REAL_VERSION = System.getenv("FORCED_VERSION")
 //val REAL_VERSION = System.getenv("FORCED_VERSION") ?: "999.0.0.999"
 
 val JVM_TARGET = JvmTarget.JVM_1_8
-val JDK_VERSION = org.gradle.api.JavaVersion.VERSION_1_8
+val JDK_VERSION = JavaVersion.VERSION_1_8
 //val JVM_TARGET = JvmTarget.JVM_11
 //val JDK_VERSION = org.gradle.api.JavaVersion.VERSION_11
 val GROUP = "com.soywiz"
@@ -424,7 +438,7 @@ subprojects {
         }
     }
 
-    tasks.withType(org.gradle.api.tasks.testing.AbstractTestTask::class) {
+    tasks.withType(AbstractTestTask::class) {
         testLogging {
             events = mutableSetOf(
                 TestLogEvent.SKIPPED,
@@ -894,9 +908,16 @@ class MicroAmper(val project: Project) {
         check(it.all { it.isLowerCase() && !it.isDigit() })
     }
 
-    data class Dep(val path: String, val exported: Boolean, val test: Boolean, val platform: String) {
+    data class Dep(val path: String, val scope: String, val test: Boolean, val platform: String) {
         val rplatform = platform.takeIf { it.isNotEmpty() } ?: "common"
-        val configuration = "$rplatform${if (test) "Test" else "Main"}${if (exported) "Api" else "Implementation"}"
+        val configuration = "$rplatform${if (test) "Test" else "Main"}${
+            when (scope) {
+                "exported" -> "Api"
+                "compile-only" -> "CompileOnly"
+                "runtime-only" -> "RuntimeOnly"
+                else -> "Implementation"
+            }
+        }"
     }
 
     fun parseFile(file: File, lines: List<String> = file.readLines()) {
@@ -929,9 +950,9 @@ class MicroAmper(val project: Project) {
                     mode.contains("dependencies") -> {
                         val platform = mode.substringAfterLast('@', "")
                         val test = mode.startsWith("test")
-                        val exported = line.contains(Regex(":\\s*exported"))
-                        val path = tline.removePrefix("-").removeSuffix(": exported").removeSuffix(":exported").trim()
-                        deps += Dep(path = path, exported = exported, test = test, platform = platform)
+                        val scope = tline.substringAfterLast(": ").trim()
+                        val path = tline.substringBeforeLast(": ").removePrefix("- ")
+                        deps += Dep(path = path, scope = scope, test = test, platform = platform)
                     }
                 }
             } else {
@@ -1009,7 +1030,7 @@ class MicroAmper(val project: Project) {
                 val isNative = platform.contains("X86") || platform.contains("X64") || platform.contains("Arm")
                 val isApple = isMacos || isIos || isTvos || isWatchos
                 val isLinux = platform.startsWith("linux")
-                val isWindows = platform.startsWith("mingw")
+                platform.startsWith("mingw")
                 val isPosix = isLinux || isApple
                 val basePlatform = getKotlinBasePlatform(platform)
                 if (isIos || isTvos) ssDependsOn(basePlatform, "appleIosTvos")
@@ -1120,7 +1141,7 @@ allprojects {
     afterEvaluate {
         afterEvaluate {
             afterEvaluate {
-                tasks.withType(org.gradle.api.tasks.testing.Test::class) {
+                tasks.withType(Test::class) {
                     //println("TEST-TASK: $this")
                     if (JDK_VERSION.majorVersion.toInt() >= 9) {
                         jvmArgs(

--- a/korlibs-crypto/api/jvm/korlibs-crypto.api
+++ b/korlibs-crypto/api/jvm/korlibs-crypto.api
@@ -25,6 +25,11 @@ public final class korlibs/crypto/AES$Companion {
 	public final fun encryptAesPcbc ([B[B[BLkorlibs/crypto/CipherPadding;)[B
 }
 
+public final class korlibs/crypto/BouncyCastleDigestsKt {
+	public static final fun asHasher (Lorg/bouncycastle/crypto/Digest;)Lkorlibs/crypto/HasherFactory;
+	public static final fun hash ([BLorg/bouncycastle/crypto/Digest;)Lkorlibs/crypto/Hash;
+}
+
 public abstract interface class korlibs/crypto/Cipher {
 	public abstract fun decrypt ([BII)V
 	public abstract fun encrypt ([BII)V
@@ -95,6 +100,11 @@ public final class korlibs/crypto/CipherWithModeAndPadding {
 	public final fun getIv ()[B
 	public final fun getMode ()Lkorlibs/crypto/CipherMode;
 	public final fun getPadding ()Lkorlibs/crypto/CipherPadding;
+}
+
+public final class korlibs/crypto/DigestsKt {
+	public static final fun asHasher (Ljava/security/MessageDigest;)Lkorlibs/crypto/HasherFactory;
+	public static final fun hash ([BLjava/security/MessageDigest;)Lkorlibs/crypto/Hash;
 }
 
 public final class korlibs/crypto/HMAC {

--- a/korlibs-crypto/module.yaml
+++ b/korlibs-crypto/module.yaml
@@ -10,5 +10,8 @@ aliases:
 dependencies:
   - com.soywiz:korlibs-encoding:6.0.0: exported
 
+dependencies@jvm:
+  - org.bouncycastle:bcprov-jdk18on:1.80: compile-only
+
 test-dependencies:
 

--- a/korlibs-crypto/src@jvm/korlibs/crypto/BouncyCastleDigests.kt
+++ b/korlibs-crypto/src@jvm/korlibs/crypto/BouncyCastleDigests.kt
@@ -1,0 +1,28 @@
+package korlibs.crypto
+
+import org.bouncycastle.crypto.Digest
+
+fun Digest.asHasher(): HasherFactory = BouncyCastleDigestHasherFactory(this)
+
+fun ByteArray.hash(algo: Digest): Hash = algo.asHasher().digest(this)
+
+internal class BouncyCastleDigestHasher(
+    val digest: Digest,
+) : NonCoreHasher(0, digest.digestSize, digest.algorithmName) {
+    override fun reset(): Hasher {
+        digest.reset()
+        return this
+    }
+
+    override fun update(data: ByteArray, offset: Int, count: Int): Hasher {
+        digest.update(data, offset, count)
+        return this
+    }
+
+    override fun digestOut(out: ByteArray) {
+        digest.doFinal(out, 0)
+    }
+}
+
+internal class BouncyCastleDigestHasherFactory(val digest: Digest) : HasherFactory(digest.algorithmName, { BouncyCastleDigestHasher(digest) })
+

--- a/korlibs-crypto/src@jvm/korlibs/crypto/Digests.kt
+++ b/korlibs-crypto/src@jvm/korlibs/crypto/Digests.kt
@@ -1,0 +1,27 @@
+package korlibs.crypto
+
+import java.security.MessageDigest
+
+fun MessageDigest.asHasher(): HasherFactory = MessageDigestHasherFactory(this)
+
+fun ByteArray.hash(algo: MessageDigest): Hash = algo.asHasher().digest(this)
+
+internal class MessageDigestHasher(
+    val md: MessageDigest,
+) : NonCoreHasher(0, md.digestLength, md.algorithm) {
+    override fun reset(): Hasher {
+        md.reset()
+        return this
+    }
+
+    override fun update(data: ByteArray, offset: Int, count: Int): Hasher {
+        md.update(data, offset, count)
+        return this
+    }
+
+    override fun digestOut(out: ByteArray) {
+        md.digest().copyInto(out, 0, 0, out.size)
+    }
+}
+
+internal class MessageDigestHasherFactory(val md: MessageDigest) : HasherFactory(md.algorithm, { MessageDigestHasher(md) })


### PR DESCRIPTION
Add functions for converting jvm digest classes to HasherFactory

Adds Hasher and HasherFactory wrappers for
  - MessageDigest
  - Digest (bouncycastle)

This also slightly modifies the `MicroAmper` implementation, to allow for other dependency scopes such as compile-only.
This was required, as the current implementation did not support compile-only dependencies. (you *really* should consider pulling in a yaml parser for that, tbh)